### PR TITLE
Add lost table 'omission' to ABI description in cyber.govern

### DIFF
--- a/cyber.govern/include/cyber.govern/cyber.govern.hpp
+++ b/cyber.govern/include/cyber.govern/cyber.govern.hpp
@@ -44,7 +44,7 @@ struct structures {
         std::vector<name> accounts;
     };
     
-    struct [[eosio::table]] omission {
+    struct omission_struct {
         name account;
         uint16_t count;
         uint64_t primary_key()const { return account.value; }
@@ -59,9 +59,8 @@ struct structures {
     using obliged_producers [[eosio::order("account","asc")]] = eosio::multi_index<"obligedprod"_n, structures::producer_struct>;
     using pending_producers [[eosio::order("id","asc")]] = eosio::singleton<"pendingprods"_n, structures::pending_producers_info>;
     
-    using omission_id_index = eosio::indexed_by<"omissionid"_n, eosio::const_mem_fun<structures::omission, uint64_t, &structures::omission::primary_key> >;
-    using omission_count_index = eosio::indexed_by<"bycount"_n, eosio::const_mem_fun<structures::omission, uint16_t, &structures::omission::by_count> >;
-    using omissions = eosio::multi_index<"omission"_n, structures::omission, omission_id_index, omission_count_index>;
+    using omission_count_index [[using eosio: order("count","desc"), non_unique]] = eosio::indexed_by<"bycount"_n, eosio::const_mem_fun<structures::omission_struct, uint16_t, &structures::omission_struct::by_count> >;
+    using omissions [[eosio::order("account","asc")]] = eosio::multi_index<"omission"_n, structures::omission_struct, omission_count_index>;
     
     void maybe_promote_producers();
     void propose_producers(structures::state_info& s);

--- a/cyber.govern/src/cyber.govern.cpp
+++ b/cyber.govern/src/cyber.govern.cpp
@@ -235,7 +235,7 @@ void govern::maybe_promote_producers() {
             omissions_table.modify(o, name(), [&](auto& o) { o.count += 1; } );
         }
         else {
-            omissions_table.emplace(_self, [&](auto& o) { o = structures::omission {
+            omissions_table.emplace(_self, [&](auto& o) { o = structures::omission_struct {
                 .account = i->account,
                 .count = 1
             };});
@@ -251,7 +251,7 @@ void govern::maybe_promote_producers() {
     symbol_code token_code = system_token.code();
     
     auto omissions_idx = omissions_table.get_index<"bycount"_n>();
-    auto omission_itr = omissions_idx.lower_bound(std::numeric_limits<decltype(structures::omission::count)>::max());
+    auto omission_itr = omissions_idx.lower_bound(std::numeric_limits<decltype(structures::omission_struct::count)>::max());
     if (omission_itr != omissions_idx.end() && omission_itr->count >= config::omission_limit) {
         if (cyber::stake::candidate_exists(omission_itr->account, token_code)) {
             INLINE_ACTION_SENDER(cyber::stake, setkey)(config::stake_name, {config::stake_name, config::active_name},

--- a/tests/cyber.govern_test_api.hpp
+++ b/tests/cyber.govern_test_api.hpp
@@ -95,8 +95,8 @@ public:
         
         wait_irreversible_block(proposed_schedule_block_num, disabled_producers);
         wait_irreversible_block(_tester->control->head_block_num(), disabled_producers);
-        BOOST_REQUIRE(_tester->control->head_block_header().schedule_version == prev_version);
-        BOOST_REQUIRE(get_block_offset() == prev_block_offset);
+        BOOST_REQUIRE_EQUAL(_tester->control->head_block_header().schedule_version, prev_version);
+        BOOST_REQUIRE_EQUAL(get_block_offset(), prev_block_offset);
         
         BOOST_REQUIRE(_tester->control->pending_block_state()->active_schedule.version == prev_version + static_cast<int>(change_version));
         auto ret = _tester->control->head_block_num() - prev_block;


### PR DESCRIPTION
Add description for the table `omission`.