### PR TITLE
Refactor cyber.govern. #317

### DIFF
--- a/cyber.bios/src/cyber.bios.cpp
+++ b/cyber.bios/src/cyber.bios.cpp
@@ -29,8 +29,22 @@ void bios::onblock(ignore<block_header> header) {
     
     eosio::block_timestamp timestamp;
     name producer;
+    uint32_t schedule_version;
+
+    static constexpr std::size_t skip_size =
+                  // eosio::block_timestamp timestamp
+                  // name producer
+        16  / 8 + // uint16_t confirmed
+        256 / 8 + // eosio::block_id_type previous
+        256 / 8 + // eosio::checksum256_type transaction_mroot
+        256 / 8;  // eosio::checksum256_type _action_mroot
+                  // uint32_t schedule_version
+                  // ...
+
     _ds >> timestamp >> producer;
-    INLINE_ACTION_SENDER(govern, onblock)(govern_name, {{govern_name, active_name}}, {producer});
+    _ds.skip(skip_size);
+    _ds >> schedule_version;
+    INLINE_ACTION_SENDER(govern, onblock)(govern_name, {{govern_name, active_name}}, {producer, schedule_version});
     //TODO: update names
 }
 

--- a/cyber.govern/include/cyber.govern/config.hpp
+++ b/cyber.govern/include/cyber.govern/config.hpp
@@ -34,8 +34,8 @@ static constexpr auto emission_max_arg = 75 * _1percent;
 static constexpr auto block_reward_pct     = 10 * _1percent;
 static constexpr auto workers_reward_pct   = 2222 * _1percent / 100; // not including block reward
 
-static uint16_t omission_limit = 100;
-static uint16_t resets_limit = 4;
+static constexpr uint16_t omission_limit = 100;
+static constexpr uint16_t resets_limit = 4;
 }
 
 } // cyber::config

--- a/cyber.govern/include/cyber.govern/cyber.govern.hpp
+++ b/cyber.govern/include/cyber.govern/cyber.govern.hpp
@@ -68,14 +68,12 @@ struct structures {
         int64_t unconfirmed_amount = 0;
         uint16_t omission_count = 0;
         uint16_t omission_resets = 0;
+        eosio::time_point_sec last_time;
 
         uint64_t primary_key()const { return account.value; }
         bool by_oblidged()const { return is_oblidged; }
         int64_t by_amount()const { return amount; }
-
-        bool is_empty() const {
-            return !unconfirmed_amount && !omission_count && !omission_resets && !is_oblidged;
-        }
+        eosio::time_point_sec by_last_time()const { return last_time; }
     };
 };
 
@@ -84,13 +82,15 @@ struct structures {
 
     using oblidged_index [[using eosio: order("is_oblidged","desc"), non_unique]] = eosio::indexed_by<"byoblidged"_n, eosio::const_mem_fun<structures::producer_struct, bool, &structures::producer_struct::by_oblidged> >;
     using balance_index [[using eosio: order("amount","desc"), non_unique]] = eosio::indexed_by<"bybalance"_n, eosio::const_mem_fun<structures::producer_struct, int64_t, &structures::producer_struct::by_amount> >;
-    using producers [[eosio::order("account","asc")]] = eosio::multi_index<"producer"_n, structures::producer_struct, oblidged_index, balance_index>;
+    using last_time_index [[using eosio: order("last_time","asc"), non_unique]] = eosio::indexed_by<"bytime"_n, eosio::const_mem_fun<structures::producer_struct, eosio::time_point_sec, &structures::producer_struct::by_last_time> >;
+    using producers [[eosio::order("account","asc")]] = eosio::multi_index<"producer"_n, structures::producer_struct, oblidged_index, balance_index, last_time_index>;
     
     void promote_producers(producers& producers_table);
     void propose_producers(structures::state_info& s);
     void reward_producers(producers& producers_table, structures::state_info& s);
     void reward_workers(structures::state_info& s);
     void burn_reward(const eosio::name& account, const int64_t& amount) const;
+    void remove_old_producers(producers& producers_table);
     int64_t get_target_emission_per_block(int64_t supply) const;
     
 public:

--- a/cyber.govern/include/cyber.govern/cyber.govern.hpp
+++ b/cyber.govern/include/cyber.govern/cyber.govern.hpp
@@ -4,6 +4,7 @@
 #include <eosio/time.hpp>
 #include <eosio/crypto.hpp>
 #include <cyber.govern/config.hpp>
+#include <eosio/binary_extension.hpp>
 
 namespace cyber {
 using eosio::name;
@@ -22,6 +23,27 @@ struct structures {
         uint32_t last_propose_block_num = 0;
         uint16_t required_producers_num = config::min_producers_num;
         uint16_t last_producers_num = 1;
+
+        // using of binary_extension is a temporary decision only for upgrade phase
+        eosio::binary_extension<uint32_t> schedule_version;
+
+        // this operator is required to set binary extension fields
+        void operator = (const state_info& s) {
+            last_schedule_increase = s.last_schedule_increase;
+            block_num = s.block_num;
+            target_emission_per_block = s.target_emission_per_block;
+            funds = s.funds;
+            last_propose_block_num = s.last_propose_block_num;
+            required_producers_num = s.required_producers_num;
+            last_producers_num = s.last_producers_num;
+
+            // temporary decision only for upgrade phase
+            if (s.schedule_version.has_value()) {
+                schedule_version.emplace(s.schedule_version.value());
+            } else {
+                schedule_version.reset();
+            }
+        }
     };
     
     struct schedule_resize_info {
@@ -39,11 +61,7 @@ struct structures {
         name account;
         uint64_t primary_key()const { return account.value; }
     };
-    
-    struct pending_producers_info {
-        std::vector<name> accounts;
-    };
-    
+
     struct omission_struct {
         name account;
         uint16_t count;
@@ -58,12 +76,11 @@ struct structures {
     using balances [[eosio::order("account","asc")]] = eosio::multi_index<"balance"_n, structures::balance_struct>;
     using unconfirmed_balances [[eosio::order("account","asc")]] = eosio::multi_index<"uncbalance"_n, structures::balance_struct>;
     using obliged_producers [[eosio::order("account","asc")]] = eosio::multi_index<"obligedprod"_n, structures::producer_struct>;
-    using pending_producers [[eosio::order("id","asc")]] = eosio::singleton<"pendingprods"_n, structures::pending_producers_info>;
-    
+
     using omission_count_index [[using eosio: order("count","desc"), non_unique]] = eosio::indexed_by<"bycount"_n, eosio::const_mem_fun<structures::omission_struct, uint16_t, &structures::omission_struct::by_count> >;
     using omissions [[eosio::order("account","asc")]] = eosio::multi_index<"omission"_n, structures::omission_struct, omission_count_index>;
     
-    void maybe_promote_producers();
+    void promote_producers();
     void propose_producers(structures::state_info& s);
     void reward_producers(balances& balances_table, structures::state_info& s);
     void reward_workers(structures::state_info& s);
@@ -71,8 +88,7 @@ struct structures {
     
 public:
     using contract::contract;
-    [[eosio::action]] void onblock(name producer);
-    [[eosio::action]] void setactprods(std::vector<name> pending_active_producers);
+    [[eosio::action]] void onblock(name producer, eosio::binary_extension<uint32_t> schedule_version);
     [[eosio::action]] void setshift(int8_t shift);
 };
 

--- a/cyber.govern/include/cyber.govern/cyber.govern.hpp
+++ b/cyber.govern/include/cyber.govern/cyber.govern.hpp
@@ -63,29 +63,29 @@ struct structures {
     
     struct producer_struct {
         name account;
-        uint64_t primary_key()const { return account.value; }
-    };
+        bool is_oblidged = false;
+        int64_t unconfirmed_amount = 0;
+        uint16_t omission_count = 0;
+        uint16_t omission_resets = 0;
 
-    struct omission_struct {
-        name account;
-        uint16_t count;
-        uint16_t resets = 0;
         uint64_t primary_key()const { return account.value; }
-        uint16_t by_count()const { return count; }
+        bool by_oblidged()const { return is_oblidged; }
+
+        bool is_empty() const {
+            return !unconfirmed_amount && !omission_count && !omission_resets && !is_oblidged;
+        }
     };
 };
 
     using state_singleton [[eosio::order("id","asc")]] = eosio::singleton<"governstate"_n, structures::state_info>;
     using balances [[eosio::order("account","asc")]] = eosio::multi_index<"balance"_n, structures::balance_struct>;
-    using unconfirmed_balances [[eosio::order("account","asc")]] = eosio::multi_index<"uncbalance"_n, structures::balance_struct>;
-    using obliged_producers [[eosio::order("account","asc")]] = eosio::multi_index<"obligedprod"_n, structures::producer_struct>;
 
-    using omission_count_index [[using eosio: order("count","desc"), non_unique]] = eosio::indexed_by<"bycount"_n, eosio::const_mem_fun<structures::omission_struct, uint16_t, &structures::omission_struct::by_count> >;
-    using omissions [[eosio::order("account","asc")]] = eosio::multi_index<"omission"_n, structures::omission_struct, omission_count_index>;
+    using oblidged_index [[using eosio: order("is_oblidged","desc"), non_unique]] = eosio::indexed_by<"byoblidged"_n, eosio::const_mem_fun<structures::producer_struct, bool, &structures::producer_struct::by_oblidged> >;
+    using producers [[eosio::order("account","asc")]] = eosio::multi_index<"producer"_n, structures::producer_struct, oblidged_index>;
     
-    void promote_producers();
+    void promote_producers(producers& producers_table);
     void propose_producers(structures::state_info& s);
-    void reward_producers(balances& balances_table, structures::state_info& s);
+    void reward_producers(producers& producers_table, balances& balances_table, structures::state_info& s);
     void reward_workers(structures::state_info& s);
     int64_t get_target_emission_per_block(int64_t supply) const;
     

--- a/tests/cyber.govern_test_api.hpp
+++ b/tests/cyber.govern_test_api.hpp
@@ -24,14 +24,9 @@ public:
      ////tables
     
     int64_t get_balance(account_name account, bool confirmed = true) {
-        if (confirmed) {
-            auto s = get_struct(_code, N(balance), account.value, "balance_struct");
-            return !s.is_null() ? s["amount"].as<int64_t>() : -1;
-        } else {
-            auto s = get_struct(_code, N(producer), account.value, "producer_struct");
-            auto r = !s.is_null() ? s["unconfirmed_amount"].as<int64_t>() : -1;
-            return (!r) ? (-1) : r;
-        }
+        auto s = get_struct(_code, N(producer), account.value, "producer_struct");
+        auto r = !s.is_null() ? s[confirmed ? "amount" : "unconfirmed_amount"].as<int64_t>() : -1;
+        return (!r) ? (-1) : r;
     }
     
     variant get_state()const {

--- a/tests/cyber.govern_test_api.hpp
+++ b/tests/cyber.govern_test_api.hpp
@@ -24,8 +24,14 @@ public:
      ////tables
     
     int64_t get_balance(account_name account, bool confirmed = true) {
-        auto s = get_struct(_code, confirmed ? N(balance) : N(uncbalance), account.value, "balance_struct");
-        return !s.is_null() ? s["amount"].as<int64_t>() : -1;
+        if (confirmed) {
+            auto s = get_struct(_code, N(balance), account.value, "balance_struct");
+            return !s.is_null() ? s["amount"].as<int64_t>() : -1;
+        } else {
+            auto s = get_struct(_code, N(producer), account.value, "producer_struct");
+            auto r = !s.is_null() ? s["unconfirmed_amount"].as<int64_t>() : -1;
+            return (!r) ? (-1) : r;
+        }
     }
     
     variant get_state()const {
@@ -98,7 +104,7 @@ public:
         BOOST_REQUIRE_EQUAL(_tester->control->head_block_header().schedule_version, prev_version);
         BOOST_REQUIRE_EQUAL(get_block_offset(), prev_block_offset);
         
-        BOOST_REQUIRE(_tester->control->pending_block_state()->active_schedule.version == prev_version + static_cast<int>(change_version));
+        BOOST_REQUIRE_EQUAL(_tester->control->pending_block_state()->active_schedule.version, prev_version + static_cast<int>(change_version));
         auto ret = _tester->control->head_block_num() - prev_block;
         BOOST_TEST_MESSAGE("--- waited " << ret << " more blocks for schedule activation");
         ret += blocks_for_update;

--- a/tests/cyber.govern_tests.cpp
+++ b/tests/cyber.govern_tests.cpp
@@ -118,7 +118,8 @@ public:
         produce_block();
         auto emission = get_emission_per_block(rate);
         BOOST_CHECK_EQUAL(govern.get_target_emission_per_block(), emission);
-        BOOST_CHECK_EQUAL(govern.get_balance(_alice),
+        auto alice_balance = govern.get_balance(_alice);
+        BOOST_CHECK_EQUAL(alice_balance == -1 ? 0 : alice_balance,
             supply_amount != max_supply_amount ? safe_pct<int64_t>(cfg::block_reward_pct, emission) : 0);
         produce_block();
     }

--- a/tests/cyber.govern_tests.cpp
+++ b/tests/cyber.govern_tests.cpp
@@ -270,10 +270,10 @@ BOOST_FIXTURE_TEST_CASE(no_rewards_test, cyber_govern_tester) try {
     BOOST_CHECK(stake.get_agent(_whale, token._symbol)["balance"].as<int64_t>() > init_amount);
     BOOST_CHECK_EQUAL(stake.get_candidate(_bob, token._symbol)["signing_key"].as<public_key_type>(), public_key_type());
     
-    BOOST_CHECK(govern.get_balance(_alice, false) > 0);
+    BOOST_CHECK_GT(govern.get_balance(_alice, false), 0);
     BOOST_CHECK_EQUAL(govern.get_balance(_bob, false), -1);
-    BOOST_CHECK(govern.get_balance(_carol, false) > 0);
-    BOOST_CHECK(govern.get_balance(_whale, false) > 0);
+    BOOST_CHECK_GT(govern.get_balance(_carol, false), 0);
+    BOOST_CHECK_GT(govern.get_balance(_whale, false), 0);
     
     BOOST_CHECK_EQUAL(govern.get_balance(_alice), -1);
     BOOST_CHECK_EQUAL(govern.get_balance(_bob), -1);

--- a/tests/cyber.govern_tests.cpp
+++ b/tests/cyber.govern_tests.cpp
@@ -413,6 +413,7 @@ BOOST_FIXTURE_TEST_CASE(producer_replacement, cyber_govern_tester) try {
         BOOST_CHECK_EQUAL(stake.get_candidate(cur_producers[p], token._symbol)["signing_key"].as<public_key_type>(), get_public_key(cur_producers[p], "active"));
     }
     govern.wait_schedule_activation(true, {cur_producers[0]});
+    produce_block(); // producer key resetting happens on the second block of the schedule round
     BOOST_CHECK_EQUAL(govern.get_active_producers(), govern.make_producers_group(cur_producers));
     BOOST_CHECK_EQUAL(stake.get_candidate(cur_producers[0], token._symbol)["signing_key"].as<public_key_type>(), public_key_type());
     for (size_t p = 1; p < cur_producers.size(); p++) {


### PR DESCRIPTION
Resolve #317:
- Remove action `cyber.govern::setactprods`
- Use schedule version from the incoming block header
- Request active producers from the nodeos
- Remove the table with pending producers
- Add clearing of old producers in cyber.govern.

Additional changes:
- Refactor tables to minimize their number `balance`, `uncbalance`, `omission`, `obligedprod` -> `producer`
- Move fields from the `schedresize` to the `governstate` 

Notice: `cyber.govern` receives a header of the previous block, so setting of oblidged producers happens on the second block of the round. It doesn't seems critical, because a validator should producer more than one block in the round.