### PR TITLE
Refactor binary extension in cyber.govern after updates in CDT.

### DIFF
--- a/cyber.govern/cyber.govern.abi
+++ b/cyber.govern/cyber.govern.abi
@@ -41,9 +41,9 @@
                 {"name": "last_propose_block_num", "type": "uint32"}, 
                 {"name": "required_producers_num", "type": "uint16"}, 
                 {"name": "last_producers_num", "type": "uint16"}, 
-                {"name": "last_resize_step", "type": "time_point_sec$"}, 
+                {"name": "schedule_version", "type": "uint32$"}, 
                 {"name": "resize_shift", "type": "int8$"}, 
-                {"name": "schedule_version", "type": "uint32$"}
+                {"name": "last_resize_step", "type": "time_point_sec$"}
             ]
         }
     ], 

--- a/cyber.govern/cyber.govern.abi
+++ b/cyber.govern/cyber.govern.abi
@@ -9,39 +9,21 @@
                 {"name": "amount", "type": "int64"}
             ]
         }, {
-            "name": "omission_struct", "base": "", 
-            "fields": [
-                {"name": "account", "type": "name"}, 
-                {"name": "count", "type": "uint16"}, 
-                {"name": "resets", "type": "uint16"}
-            ]
-        }, {
             "name": "onblock", "base": "", 
             "fields": [
-                {"name": "producer", "type": "name"}
-            ]
-        }, {
-            "name": "pending_producers_info", "base": "", 
-            "fields": [
-                {"name": "id", "type": "uint64"}, 
-                {"name": "accounts", "type": "name[]"}
+                {"name": "producer", "type": "name"}, 
+                {"name": "schedule_version", "type": "uint32$"}
             ]
         }, {
             "name": "producer_struct", "base": "", 
             "fields": [
-                {"name": "account", "type": "name"}
-            ]
-        }, {
-            "name": "schedule_resize_info", "base": "", 
-            "fields": [
-                {"name": "id", "type": "uint64"}, 
-                {"name": "last_step", "type": "time_point_sec"}, 
-                {"name": "shift", "type": "int8"}
-            ]
-        }, {
-            "name": "setactprods", "base": "", 
-            "fields": [
-                {"name": "pending_active_producers", "type": "name[]"}
+                {"name": "account", "type": "name"}, 
+                {"name": "is_oblidged", "type": "bool"}, 
+                {"name": "amount", "type": "int64"}, 
+                {"name": "unconfirmed_amount", "type": "int64"}, 
+                {"name": "omission_count", "type": "uint16"}, 
+                {"name": "omission_resets", "type": "uint16"}, 
+                {"name": "last_time", "type": "time_point_sec"}
             ]
         }, {
             "name": "setshift", "base": "", 
@@ -58,13 +40,15 @@
                 {"name": "funds", "type": "int64"}, 
                 {"name": "last_propose_block_num", "type": "uint32"}, 
                 {"name": "required_producers_num", "type": "uint16"}, 
-                {"name": "last_producers_num", "type": "uint16"}
+                {"name": "last_producers_num", "type": "uint16"}, 
+                {"name": "last_resize_step", "type": "time_point_sec$"}, 
+                {"name": "resize_shift", "type": "int8$"}, 
+                {"name": "schedule_version", "type": "uint32$"}
             ]
         }
     ], 
     "actions": [
         {"name": "onblock", "type": "onblock"}, 
-        {"name": "setactprods", "type": "setactprods"}, 
         {"name": "setshift", "type": "setshift"}
     ], 
     "events": [
@@ -89,52 +73,26 @@
                 }
             ]
         }, {
-            "name": "obligedprod", "type": "producer_struct", 
-            "indexes": [{
-                    "name": "primary", "unique": true, 
-                    "orders": [
-                        {"field": "account", "order": "asc"}
-                    ]
-                }
-            ]
-        }, {
-            "name": "omission", "type": "omission_struct", 
+            "name": "producer", "type": "producer_struct", 
             "indexes": [{
                     "name": "primary", "unique": true, 
                     "orders": [
                         {"field": "account", "order": "asc"}
                     ]
                 }, {
-                    "name": "bycount", "unique": false, 
+                    "name": "byoblidged", "unique": false, 
                     "orders": [
-                        {"field": "count", "order": "desc"}
+                        {"field": "is_oblidged", "order": "desc"}
                     ]
-                }
-            ]
-        }, {
-            "name": "pendingprods", "type": "pending_producers_info", 
-            "indexes": [{
-                    "name": "primary", "unique": true, 
+                }, {
+                    "name": "bybalance", "unique": false, 
                     "orders": [
-                        {"field": "id", "order": "asc"}
+                        {"field": "amount", "order": "desc"}
                     ]
-                }
-            ]
-        }, {
-            "name": "schedresize", "type": "schedule_resize_info", 
-            "indexes": [{
-                    "name": "primary", "unique": true, 
+                }, {
+                    "name": "bytime", "unique": false, 
                     "orders": [
-                        {"field": "id", "order": "asc"}
-                    ]
-                }
-            ]
-        }, {
-            "name": "uncbalance", "type": "balance_struct", 
-            "indexes": [{
-                    "name": "primary", "unique": true, 
-                    "orders": [
-                        {"field": "account", "order": "asc"}
+                        {"field": "last_time", "order": "asc"}
                     ]
                 }
             ]

--- a/cyber.govern/include/cyber.govern/cyber.govern.hpp
+++ b/cyber.govern/include/cyber.govern/cyber.govern.hpp
@@ -25,34 +25,9 @@ struct structures {
         uint16_t last_producers_num = 1;
 
         // using of binary_extension is a temporary decision only for upgrade phase
-        eosio::binary_extension<time_point_sec> last_resize_step;
-        eosio::binary_extension<int8_t> resize_shift;
-        eosio::binary_extension<uint32_t> schedule_version;
-
-        // this operator is required to set binary extension fields
-        void operator = (const state_info& s) {
-            last_schedule_increase = s.last_schedule_increase;
-            block_num = s.block_num;
-            target_emission_per_block = s.target_emission_per_block;
-            funds = s.funds;
-            last_propose_block_num = s.last_propose_block_num;
-            required_producers_num = s.required_producers_num;
-            last_producers_num = s.last_producers_num;
-
-            set_extension_field(last_resize_step, s.last_resize_step);
-            set_extension_field(resize_shift, s.resize_shift);
-            set_extension_field(schedule_version, s.schedule_version);
-        }
-
-        template<typename T>
-        void set_extension_field(eosio::binary_extension<T>& dst, const eosio::binary_extension<T>& src) const {
-            // temporary decision only for upgrade phase
-            if (src.has_value()) {
-                dst.emplace(src.value());
-            } else {
-                dst.reset();
-            }
-        }
+        eosio::binary_extension<time_point_sec, eosio::write_strategy::no_value> last_resize_step;
+        eosio::binary_extension<int8_t, eosio::write_strategy::no_value> resize_shift;
+        eosio::binary_extension<uint32_t, eosio::write_strategy::no_value> schedule_version;
     };
 
     struct [[using eosio: event("burnreward"), contract("cyber.govern")]] balance_struct {
@@ -95,7 +70,7 @@ struct structures {
     
 public:
     using contract::contract;
-    [[eosio::action]] void onblock(name producer, eosio::binary_extension<uint32_t> schedule_version);
+    [[eosio::action]] void onblock(name producer, const eosio::binary_extension<uint32_t>& schedule_version);
     [[eosio::action]] void setshift(int8_t shift);
 };
 

--- a/cyber.govern/include/cyber.govern/cyber.govern.hpp
+++ b/cyber.govern/include/cyber.govern/cyber.govern.hpp
@@ -25,9 +25,9 @@ struct structures {
         uint16_t last_producers_num = 1;
 
         // using of binary_extension is a temporary decision only for upgrade phase
-        eosio::binary_extension<time_point_sec, eosio::write_strategy::no_value> last_resize_step;
-        eosio::binary_extension<int8_t, eosio::write_strategy::no_value> resize_shift;
         eosio::binary_extension<uint32_t, eosio::write_strategy::no_value> schedule_version;
+        eosio::binary_extension<int8_t, eosio::write_strategy::no_value> resize_shift;
+        eosio::binary_extension<time_point_sec, eosio::write_strategy::no_value> last_resize_step;
     };
 
     struct [[using eosio: event("burnreward"), contract("cyber.govern")]] balance_struct {
@@ -70,7 +70,7 @@ struct structures {
     
 public:
     using contract::contract;
-    [[eosio::action]] void onblock(name producer, const eosio::binary_extension<uint32_t>& schedule_version);
+    [[eosio::action]] void onblock(name producer, eosio::binary_extension<uint32_t> schedule_version);
     [[eosio::action]] void setshift(int8_t shift);
 };
 

--- a/cyber.govern/src/cyber.govern.cpp
+++ b/cyber.govern/src/cyber.govern.cpp
@@ -11,7 +11,7 @@ using namespace cyber::config;
 
 namespace cyber {
 
-void govern::onblock(name producer, eosio::binary_extension<uint32_t> schedule_version) {
+void govern::onblock(name producer, const eosio::binary_extension<uint32_t>& schedule_version) {
     require_auth(_self);
     
     auto state = state_singleton(_self, _self.value);
@@ -74,7 +74,7 @@ void govern::onblock(name producer, eosio::binary_extension<uint32_t> schedule_v
         s.schedule_version.emplace(schedule_version.value());
     }
 
-    state.set(s, _self);
+    state.set(std::move(s), _self);
 }
 
 void govern::reward_workers(structures::state_info& s) {

--- a/cyber.govern/src/cyber.govern.cpp
+++ b/cyber.govern/src/cyber.govern.cpp
@@ -11,7 +11,7 @@ using namespace cyber::config;
 
 namespace cyber {
 
-void govern::onblock(name producer, const eosio::binary_extension<uint32_t>& schedule_version) {
+void govern::onblock(name producer, eosio::binary_extension<uint32_t> schedule_version) {
     require_auth(_self);
     
     auto state = state_singleton(_self, _self.value);
@@ -72,6 +72,8 @@ void govern::onblock(name producer, const eosio::binary_extension<uint32_t>& sch
             remove_old_producers(producers_table);
         }
         s.schedule_version.emplace(schedule_version.value());
+    } else {
+        s.schedule_version.emplace(0);
     }
 
     state.set(std::move(s), _self);
@@ -263,7 +265,7 @@ void govern::setshift(int8_t shift) {
     auto s = state.get(); // no default values, because it was created on the first block, errors can happens only in tests
     eosio::check(shift != s.resize_shift.value(), "the shift has not changed");
     s.resize_shift.emplace(shift);
-    state.set(s, _self);
+    state.set(std::move(s), _self);
 }
 
 void govern::promote_producers(producers& producers_table) {


### PR DESCRIPTION
Refactor using of binary extension in cyber.govern to use write_strategy from cyberway/cyberway.cdt#175 and copy/move operators from cyberway/cyberway.cdt#176