### PR TITLE
Update generated abi when build contracts locally #326

### DIFF
--- a/.buildkite/steps/build-image.sh
+++ b/.buildkite/steps/build-image.sh
@@ -24,4 +24,4 @@ if [[ -z ${BUILDER_TAG+x} ]]; then
     docker pull cyberway/builder:${BUILDER_TAG}
 fi
 
-docker build -t cyberway/cyberway.contracts:${REVISION} --build-arg=version=${REVISION} --build-arg=cw_tag=${CW_TAG} --build-arg=cdt_tag=${CDT_TAG}  --build-arg=builder_tag=${BUILDER_TAG} -f Docker/Dockerfile .
+docker build -t cyberway/cyberway.contracts:${REVISION} --build-arg=version=${REVISION} --build-arg=cw_tag=${CW_TAG} --build-arg=cdt_tag=${CDT_TAG}  --build-arg=builder_tag=${BUILDER_TAG} --build-arg=ci_build=${CI} -f Docker/Dockerfile .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ endmacro()
 macro(add_contract_with_checked_abi CONTRACT_NAME TARGET ABIFILE)
     add_contract(${CONTRACT_NAME} ${TARGET} ${ARGN})
     get_target_property(BINOUTPUT ${TARGET}.wasm BINARY_DIR)
-    if(CI_BUILD STREQUAL "true")
+    if(ABICHECK STREQUAL "true")
       add_custom_command(TARGET ${TARGET}.wasm POST_BUILD
          COMMAND ${PROJECT_SOURCE_DIR}/scripts/deployutils/abiprinter.py <${BINOUTPUT}/${TARGET}.abi >${BINOUTPUT}/${TARGET}.abi.pretty)
       add_custom_target(${TARGET}.abicheck ALL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,17 @@ endmacro()
 macro(add_contract_with_checked_abi CONTRACT_NAME TARGET ABIFILE)
     add_contract(${CONTRACT_NAME} ${TARGET} ${ARGN})
     get_target_property(BINOUTPUT ${TARGET}.wasm BINARY_DIR)
-    add_custom_command(TARGET ${TARGET}.wasm POST_BUILD
-        COMMAND ${PROJECT_SOURCE_DIR}/scripts/deployutils/abiprinter.py <${BINOUTPUT}/${TARGET}.abi >${BINOUTPUT}/${TARGET}.abi.pretty)
-    add_custom_target(${TARGET}.abicheck ALL
-        COMMAND ${CYBERWAY_ABIDIFF} ${CMAKE_CURRENT_SOURCE_DIR}/${ABIFILE} ${BINOUTPUT}/${TARGET}.abi
-        DEPENDS ${TARGET}.wasm ${ABIFILE}
-    )
+    if(CI_BUILD STREQUAL "true")
+      add_custom_command(TARGET ${TARGET}.wasm POST_BUILD
+         COMMAND ${PROJECT_SOURCE_DIR}/scripts/deployutils/abiprinter.py <${BINOUTPUT}/${TARGET}.abi >${BINOUTPUT}/${TARGET}.abi.pretty)
+      add_custom_target(${TARGET}.abicheck ALL
+         COMMAND ${CYBERWAY_ABIDIFF} ${CMAKE_CURRENT_SOURCE_DIR}/${ABIFILE} ${BINOUTPUT}/${TARGET}.abi
+         DEPENDS ${TARGET}.wasm ${ABIFILE}
+      )
+    else()
+      add_custom_command(TARGET ${TARGET}.wasm POST_BUILD
+      COMMAND ${PROJECT_SOURCE_DIR}/scripts/deployutils/abiprinter.py <${BINOUTPUT}/${TARGET}.abi >${CMAKE_CURRENT_SOURCE_DIR}/${ABIFILE})
+   endif()
 endmacro()
 
 macro(add_contract_with_abi TARGET ABIFILE)

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,7 +13,7 @@ ENV CYBERWAY /opt/cyberway/
 
 COPY . /cyberway.contracts
 
-ARG ci_build=no
+ARG ci_build
 
 RUN ldconfig && cd cyberway.contracts \
     && cmake -H. -B"build" \
@@ -22,7 +22,7 @@ RUN ldconfig && cd cyberway.contracts \
         -DCMAKE_INSTALL_PREFIX=/opt/cyberway.contracts/ \
         -Dcyberway.cdt_DIR=/opt/cyberway.cdt/lib/cmake/cyberway.cdt \
         -DEOSIO_ROOT=$CYBERWAY \
-        -DCI_BUILD=$ci_build \
+        -DABICHECK=$ci_build \
     && cmake --build build --target install
 
 FROM ubuntu:18.04

--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -13,6 +13,8 @@ ENV CYBERWAY /opt/cyberway/
 
 COPY . /cyberway.contracts
 
+ARG ci_build=no
+
 RUN ldconfig && cd cyberway.contracts \
     && cmake -H. -B"build" \
         -GNinja \
@@ -20,6 +22,7 @@ RUN ldconfig && cd cyberway.contracts \
         -DCMAKE_INSTALL_PREFIX=/opt/cyberway.contracts/ \
         -Dcyberway.cdt_DIR=/opt/cyberway.cdt/lib/cmake/cyberway.cdt \
         -DEOSIO_ROOT=$CYBERWAY \
+        -DCI_BUILD=$ci_build \
     && cmake --build build --target install
 
 FROM ubuntu:18.04


### PR DESCRIPTION
also updates deployutils

resolves #326

***
When build contract locally, its abi updates using abigen and abiprinter.py.
When push to CI, a pushed abi being verified with generated one.