### PR TITLE
Initialize autorcmode for CYBER stake #339

### DIFF
--- a/cyber.bios/cyber.bios.abi
+++ b/cyber.bios/cyber.bios.abi
@@ -98,6 +98,11 @@
                 {"name": "permission", "type": "name"}
             ]
         }, {
+            "name": "initautorc", "base": "", 
+            "fields": [
+                {"name": "enable", "type": "bool"}
+            ]
+        }, {
             "name": "key_weight", "base": "", 
             "fields": [
                 {"name": "key", "type": "public_key"}, 
@@ -233,6 +238,7 @@
         {"name": "checkversion", "type": "checkversion"}, 
         {"name": "checkwin", "type": "checkwin"}, 
         {"name": "deleteauth", "type": "deleteauth"}, 
+        {"name": "initautorc", "type": "initautorc"}, 
         {"name": "linkauth", "type": "linkauth"}, 
         {"name": "newaccount", "type": "newaccount"}, 
         {"name": "onblock", "type": "onblock"}, 

--- a/cyber.bios/include/cyber.bios/cyber.bios.hpp
+++ b/cyber.bios/include/cyber.bios/cyber.bios.hpp
@@ -187,6 +187,8 @@ namespace cyber {
          [[eosio::action]]
          void providebw(name provider, name account) {} // defined in cyberway/libraries/chain/cyberway/cyberway_contract.cpp
 
+         [[eosio::action]] void initautorc(bool enable);
+
          [[eosio::on_notify(CYBER_STAKE "::withdraw")]] void on_stake_withdraw(name account, asset quantity);
          [[eosio::on_notify(CYBER_STAKE "::provide")]] void on_stake_provide(name provider_name, name consumer_name, asset quantity);
 

--- a/cyber.bios/src/cyber.bios.cpp
+++ b/cyber.bios/src/cyber.bios.cpp
@@ -170,6 +170,24 @@ void bios::newaccount(name creator, name newact, ignore<authority> owner, ignore
     }
 }
 
+void bios::initautorc(bool enable) {
+    require_auth(producers_name);
+
+    action(
+        permission_level{"cyber"_n, active_name},
+        "cyber"_n, "linkauth"_n,
+        std::make_tuple("cyber"_n, "cyber.stake"_n, "setautorcmode"_n, "prods"_n)
+    ).send();
+
+    if(enable) {
+        action(
+            permission_level{"cyber"_n, active_name},
+            "cyber.stake"_n, "setautorcmode"_n,
+            std::make_tuple(symbol_code("CYBER"), true)
+        ).send();
+    }
+}
+
 void bios::check_stake(name account) {
     auto token_code = system_token.code();
     auto cost = eosio::get_used_resources_cost(account);


### PR DESCRIPTION
Resolve #339 
Add `cyber:initrcmode` which requires `cyber.prods@active` authority, so it can be used immediately.
This action link `cyber.stake:setautorcmode` with `cyber@prods` authority and enable (if specified) autorcmode.